### PR TITLE
feat(cli): Make create command default and refine argument handling

### DIFF
--- a/bin/run.ts
+++ b/bin/run.ts
@@ -1,9 +1,11 @@
-import yargs, { CommandModule } from 'yargs';
+import yargs, { CommandModule, Options } from 'yargs';
 import 'dotenv/config';
 import { commands } from '../src';
 import { bgBlue, bold, red } from 'picocolors';
+import { hideBin } from 'yargs/helpers';
 
-const run = yargs(process.argv.slice(2));
+const run = yargs(hideBin(process.argv));
+
 run.usage(
   bgBlue(
     `Welcome to the ${bold(red('PR Commit AI Agent'))}!
@@ -11,8 +13,16 @@ run.usage(
   )
 );
 
+const firstCommand = commands[0] as unknown as Required<CommandModule>;
+run.command(
+  [firstCommand.command.toString(), '$0'],
+  firstCommand.describe.toString(),
+  firstCommand.builder as { [key: string]: Options },
+  firstCommand.handler
+);
+
 for (const command of commands) {
   run.command(command as CommandModule);
 }
 
-run.demandCommand(1, 'You need at least one command before moving on').help().argv;
+run.help().argv;

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -73,7 +73,7 @@ let model: string;
 let provider: LLMProvider;
 
 // Initialize global variables
-export function initializeGlobals(argv: ArgumentsCamelCase<CreateArgv>) {
+function initializeGlobals(argv: ArgumentsCamelCase<CreateArgv>) {
   globalConfirm = async (message: string, options: PromptOptions = { type: 'confirm' }) => {
     if (argv.yes) {
       logger.info(yellow(`[Auto-confirmed] ${message}`));
@@ -442,7 +442,7 @@ ${commitData.commitMessage}
   } catch (e) {
     logger.debug('Raw response:', res);
     logger.error(red(`Failed to parse LLM response as JSON: ${(e as Error).message}`));
-    throw new Error('Invalid LLM response format');
+    process.exit(0);
   }
 
   return commitData;

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,4 +3,4 @@ import * as create from './create';
 import * as config from './config';
 import * as logs from './logs';
 
-export const commands = [info, create, config, logs];
+export const commands = [create, info, config, logs];


### PR DESCRIPTION
## Summary
This pull request makes the `create` command the default action when the CLI is run without a specific command. It also refines argument handling using `yargs/helpers/hideBin` and makes an internal function private.

## Problem Statement
The primary function of the CLI, creating PR/commit messages, required users to explicitly type `create`. Argument parsing could be standardized using yargs helpers.

## Changes Made
- Made the `create` command the default when no command is explicitly provided.
- Updated argument parsing logic to use `yargs/helpers/hideBin` for cleaner argument handling.
- Reordered the command list to ensure `create` is the first command, enabling the default behavior.
- Changed the `initializeGlobals` function in `create.ts` to be internal to the module.
- Modified error handling in `parseLLMResponse` to exit the process on parsing failure.

## Implementation Details
- CLI: Modified `bin/run.ts` to register the first command as the default (`$0`) and removed the requirement for a command. Updated argument parsing with `hideBin`.
- Backend/Business Logic: Changed `initializeGlobals` function signature from `export function` to `function` in `src/commands/create.ts`. Replaced `throw new Error` with `process.exit(0)` in `parseLLMResponse` catch block.
- State Management: No changes.

## Risk Assessment
- Potential side effects: Exiting with code `0` on an LLM parsing error (`process.exit(0)`) is incorrect as it indicates success despite a failure. This hides actual errors from calling processes or CI systems.
- Backward compatibility concerns: Users explicitly calling `create` will see no change. Removing `demandCommand` might slightly alter behavior for completely invalid inputs, but defaulting mitigates this.
- Reliability: The change in error handling in `parseLLMResponse` significantly reduces reliability by masking parsing failures.

## Testing Approach
- Manual test procedures: Verify running the CLI with no command, with `create` explicitly, and with other commands (`info`, `config`, `logs`). Test with various valid and invalid arguments. Attempt to simulate an invalid LLM response format to observe the exit behavior.

## Deployment Notes
- No specific database migrations, environment configuration changes, or dependency updates required beyond standard code deployment.

## Technical Analysis by Domain
- CLI Applications:
  - Command structure: The `create` command is now aliased as `$0`, making it the default.
  - Option/flag consistency: Argument parsing is standardized using `hideBin`.
  - Error messaging and exit codes: The change in `parseLLMResponse` to use `process.exit(0)` on error is a critical issue that needs review.
- Backend:
  - Error handling implementation: The change in `parseLLMResponse` to exit with code 0 on failure is incorrect and should be reverted to throwing an error or exiting with a non-zero code.
  - Service architecture patterns: Making `initializeGlobals` internal is a good encapsulation improvement.

## Change Classification
- feat(cli): Implemented the feature to make the `create` command the default CLI action.
- refactor(cli): Refactored argument handling using `hideBin` and made `initializeGlobals` internal.
- fix(error-handling): *Potential bug introduced* by changing error handling in `parseLLMResponse` to `process.exit(0)` on failure.

## Review Priority Guidelines
- Critical Path Analysis: The error handling change in `parseLLMResponse` is in a critical path (processing LLM output) and requires immediate review due to its impact on reliability and error reporting.
- User Experience Impact: Defaulting the command improves the user experience for the primary use case.
- System Interaction Points: Error handling related to the LLM interaction is directly affected.

## Cross-Functional Requirements Analysis
- Reliability: Significantly negatively impacted by the incorrect error handling in `parseLLMResponse`.
- Maintainability: Slightly improved by encapsulating `initializeGlobals`.

## Actionable Feedback
- **Critical:** The change in `src/commands/create.ts`, specifically in the `parseLLMResponse` function's catch block, replaces `throw new Error(...)` with `process.exit(0)`. Exiting with code `0` signifies success, which is incorrect when an error occurs. This will hide parsing failures from users and automated systems. Please change this to either `throw e;` (re-throwing the caught error) or `process.exit(1);` (exiting with a non-zero code to indicate failure). Re-throwing the error is generally preferred as it allows for potential higher-level error handling.
- **Minor:** The change making `initializeGlobals` internal is a good refactor for encapsulation.