### PR TITLE
feat(create): add option to create draft pull requests

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -28,7 +28,7 @@ interface CreateArgv {
   provider?: string;
   model?: string;
   pr?: boolean;
-  draft?: boolean; // <-- Add draft option
+  draft?: boolean;
 }
 
 /**

--- a/src/services/prompts.ts
+++ b/src/services/prompts.ts
@@ -114,7 +114,6 @@ Categorize using specific prefixes with detailed scope:
 
 ## 5. Provide actionable feedback that addresses both immediate code quality and long-term maintainability. Use concrete examples when suggesting improvements.
 
-## 6. Use correct sentence case.
-
+## 6. Use correct sentence case  Make sure the commit message and PR title are clear and concise, and follow the provided guidelines and follows @semantic-release/commit-analyzer angular convention.
 `;
 }


### PR DESCRIPTION
## Summary
This pull request introduces a new command-line option `--draft` to the `create` command, allowing users to generate pull requests in a draft state directly from the CLI.

## Problem Statement
Previously, the `create` command only supported creating standard pull requests. Users who wished to start a PR as a draft had to manually convert it after creation, adding an extra step to their workflow.

## Changes Made:
- Added a new optional boolean argument `--draft` to the `create` command's builder.
- Updated the `createAndPushPR` function to accept a `draft` boolean flag.
- Modified the `gh pr create` command execution within `createAndPushPR` to conditionally include the `--draft` flag based on the new argument.
- Updated the prompt text in `src/services/prompts.ts` for clarity on commit message and PR title guidelines.