### PR TITLE
docs(readme): update GitHub CLI requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ GGPR is a smart CLI tool leveraging AI to enhance Git workflows by generating hi
 - **Node.js** v18+
 - **pnpm** (recommended) or npm
 - **Git** v2.25+
-- **GitHub CLI** (optional) for PR creation
+- **GitHub CLI** (required) for PR creation
 
 ## 🛠️ Installation
 

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -119,6 +119,7 @@ export async function handler(argv: ArgumentsCamelCase<CreateArgv>) {
   initializeGlobals(argv);
 
   const ready = await globalConfirm(`Are you ready to create an AI PR?`);
+  //
   if (!ready) return;
 
   try {


### PR DESCRIPTION
## Summary
Updates the README to accurately reflect the requirement for GitHub CLI when using the PR creation command.

## Problem Statement
The previous documentation incorrectly listed GitHub CLI as optional, while the `create` command relies on it for creating pull requests.

## Changes Made
- Updated `README.md` to change "GitHub CLI (optional)" to "GitHub CLI (required)".