### PR TITLE
chore(deps): update ai dependency to 4.3.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@ai-sdk/provider": "1.1.3",
     "@anthropic-ai/sdk": "0.40.1",
     "@eslint/js": "9.25.1",
-    "ai": "4.3.11",
+    "ai": "4.3.12",
     "conf": "^13.1.0",
     "consola": "3.4.2",
     "dotenv": "16.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: 9.25.1
         version: 9.25.1
       ai:
-        specifier: 4.3.11
-        version: 4.3.11(react@19.1.0)(zod@3.24.3)
+        specifier: 4.3.12
+        version: 4.3.12(react@19.1.0)(zod@3.24.3)
       conf:
         specifier: ^13.1.0
         version: 13.1.0
@@ -1163,8 +1163,8 @@ packages:
     resolution: {integrity: sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==}
     engines: {node: '>=18'}
 
-  ai@4.3.11:
-    resolution: {integrity: sha512-5korDAKCsDXE5HwglOJ7NxJ32TEj2NmKGQPefcMJMKkjxeJJjC6NfM8qLtPCCk8FoAVtYdIMYPy8dzux423QLg==}
+  ai@4.3.12:
+    resolution: {integrity: sha512-DWjtPI8YJVyvcJx27KW1i6PrwkbjTewflfH+qPtIuoAP0YYs6bH17cAihTt4je+itgazLXK07ZCbV019YkdYjw==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
@@ -5274,7 +5274,7 @@ snapshots:
       clean-stack: 5.2.0
       indent-string: 5.0.0
 
-  ai@4.3.11(react@19.1.0)(zod@3.24.3):
+  ai@4.3.12(react@19.1.0)(zod@3.24.3):
     dependencies:
       '@ai-sdk/provider': 1.1.3
       '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)


### PR DESCRIPTION
## Summary
This pull request updates the `ai` dependency to version 4.3.12. This is a routine maintenance task to keep dependencies current.

## Problem Statement
Keeping project dependencies up-to-date is essential for incorporating the latest bug fixes, performance improvements, and minor features provided by external libraries. This update addresses the need to use the most recent patch version of the `ai` SDK.

## Changes Made
- Updated the `ai` dependency version from `4.3.11` to `4.3.12` in `package.json`.
- Regenerated the `pnpm-lock.yaml` file to reflect the updated dependency version and its transitive dependencies.

## Change Classification
- chore(deps): Routine update of the `ai` dependency to version 4.3.12.
  - Scope: Project dependencies (`package.json`, `pnpm-lock.yaml`).
  - User-facing changes: None expected from a patch version update.
  - Technical debt addressed: Keeps dependencies current, reducing potential future compatibility issues.

## Feedback
- Verify that the build completes successfully after the dependency update.
- Perform basic smoke testing to ensure core functionalities relying on the `ai` SDK are still working as expected, although a patch version update is generally low risk.
- Consider automating dependency updates for patch and minor versions using tools like Dependabot or Renovate Bot to streamline this process.