### PR TITLE
feat(cli): Implement PR update flow, enhance log viewer, and add log deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ flowchart TD
     Start([Start GGPR]) --> InitConfig[Initialize Configs & Settings]
     InitConfig --> GitStatus[Get Git Status]
     GitStatus --> BranchCheck{Determine\nTarget Branch}
-    
+
     %% Branch Selection Flow
     BranchCheck -->|Find Tracking Branch| TrackingExists{Tracking\nBranch Exists?}
     TrackingExists -->|Yes| ConfirmTracking{Confirm\nTracking Branch?}
@@ -187,7 +187,7 @@ flowchart TD
     ConfirmBranch -->|Yes| TargetBranchSet[Set Target Branch]
     ConfirmBranch -->|No| ExitProcess([Exit Process])
     UseTracking --> TargetBranchSet
-    
+
     %% Uncommitted Changes Flow
     TargetBranchSet --> CheckChanges{Working Dir\nClean?}
     CheckChanges -->|Yes| OptimizeCommits[Optimize Commit Messages]
@@ -204,7 +204,7 @@ flowchart TD
     ConfirmCommit -->|Yes| CreateCommit[Create Commit]
     CreateCommit --> MarkCommit[Mark as Created by Tool]
     MarkCommit --> OptimizeCommits
-    
+
     %% Optimize Commits Flow
     OptimizeCommits --> CommitsExists{Commits to\nOptimize?}
     CommitsExists -->|No| CheckPRFlag
@@ -224,14 +224,14 @@ flowchart TD
     AmendCommit --> MarkAmended[Mark as Created by Tool]
     MarkAmended --> CheckPRFlag
     MarkNoChanges --> CheckPRFlag
-    
+
     %% PR Creation Flow
     CheckPRFlag{Create PR?} -->|No| Complete([Complete])
     CheckPRFlag -->|Yes| ConfirmPR{Proceed with\nCreating PR?}
     ConfirmPR -->|No| Complete
     ConfirmPR -->|Yes| CheckExistingPR[Check for Existing PR]
     CheckExistingPR --> ExistingPR{PR Already\nExists?}
-    
+
     %% Existing PR Flow
     ExistingPR -->|Yes| ConfirmUpdate{Update\nExisting PR?}
     ConfirmUpdate -->|No| GeneratePRDetails
@@ -244,7 +244,7 @@ flowchart TD
     ConfirmUpdateDesc -->|No| Complete
     ConfirmUpdateDesc -->|Yes| UpdatePR[Update PR Title/Description]
     UpdatePR --> Complete
-    
+
     %% New PR Flow
     ExistingPR -->|No| GeneratePRDetails[Generate PR Details with AI]
     GeneratePRDetails --> ConfirmPRDetails{Create PR with\nthese Details?}
@@ -265,12 +265,12 @@ flowchart TD
     CreatePRGH --> PRSuccess[PR Created Successfully]
     ShowManualInstructions --> Complete
     PRSuccess --> Complete
-    
+
     classDef processNode fill:#d4f1f9,stroke:#0e5974,stroke-width:1px;
     classDef decisionNode fill:#ffe6cc,stroke:#d79b00,stroke-width:1px;
     classDef startEndNode fill:#d5e8d4,stroke:#82b366,stroke-width:2px;
     classDef errorNode fill:#f8cecc,stroke:#b85450,stroke-width:1px;
-    
+
     class Start,Complete,ExitProcess startEndNode;
     class BranchCheck,TrackingExists,ConfirmTracking,ConfirmBranch,CheckChanges,HandleChanges,AskAI,ConfirmCommit,CommitsExists,OptimizeConfirm,IsCreatedByTool,IsMergeCommit,AINeedsImprovement,ConfirmAmend,CheckPRFlag,ConfirmPR,ExistingPR,ConfirmUpdate,UpdatePRDesc,ConfirmUpdateDesc,ConfirmPRDetails,CheckBranchTarget,ConfirmNewBranch,CreatePRWithGH,GHCliAvailable decisionNode;
     class ExitProcess errorNode;

--- a/README.md
+++ b/README.md
@@ -168,6 +168,115 @@ ggpr config
 4. **Branch Creation**: Create a branch with an AI-generated name.
 5. **PR Creation**: Generate a PR with an AI-generated title and description.
 
+### Workflow Diagram
+
+```mermaid
+flowchart TD
+    Start([Start GGPR]) --> InitConfig[Initialize Configs & Settings]
+    InitConfig --> GitStatus[Get Git Status]
+    GitStatus --> BranchCheck{Determine\nTarget Branch}
+    
+    %% Branch Selection Flow
+    BranchCheck -->|Find Tracking Branch| TrackingExists{Tracking\nBranch Exists?}
+    TrackingExists -->|Yes| ConfirmTracking{Confirm\nTracking Branch?}
+    TrackingExists -->|No| FetchRemotes[Fetch Remote Branches]
+    ConfirmTracking -->|Yes| UseTracking[Use Tracking Branch]
+    ConfirmTracking -->|No| FetchRemotes
+    FetchRemotes --> UserSelectBranch[User Selects Branch]
+    UserSelectBranch --> ConfirmBranch{Confirm\nBranch Selection?}
+    ConfirmBranch -->|Yes| TargetBranchSet[Set Target Branch]
+    ConfirmBranch -->|No| ExitProcess([Exit Process])
+    UseTracking --> TargetBranchSet
+    
+    %% Uncommitted Changes Flow
+    TargetBranchSet --> CheckChanges{Working Dir\nClean?}
+    CheckChanges -->|Yes| OptimizeCommits[Optimize Commit Messages]
+    CheckChanges -->|No| HandleChanges{Commit\nChanges?}
+    HandleChanges -->|No| ExitProcess
+    HandleChanges -->|Yes| AnalyzeChanges[Analyze Changes with AI]
+    AnalyzeChanges --> CollectModified[Collect Modified Files]
+    CollectModified --> GetDiffs[Get Diffs for Each File]
+    GetDiffs --> AskAI{Send to AI\nfor Analysis?}
+    AskAI -->|No| ExitProcess
+    AskAI -->|Yes| GenerateCommitMsg[Generate Commit Message]
+    GenerateCommitMsg --> ConfirmCommit{Proceed with\nCommit?}
+    ConfirmCommit -->|No| ExitProcess
+    ConfirmCommit -->|Yes| CreateCommit[Create Commit]
+    CreateCommit --> MarkCommit[Mark as Created by Tool]
+    MarkCommit --> OptimizeCommits
+    
+    %% Optimize Commits Flow
+    OptimizeCommits --> CommitsExists{Commits to\nOptimize?}
+    CommitsExists -->|No| CheckPRFlag
+    CommitsExists -->|Yes| OptimizeConfirm{Optimize\nCommits?}
+    OptimizeConfirm -->|No| CheckPRFlag
+    OptimizeConfirm -->|Yes| CheckLastCommit[Check Last Commit]
+    CheckLastCommit --> IsCreatedByTool{Created by\nThis Tool?}
+    IsCreatedByTool -->|Yes| CheckPRFlag
+    IsCreatedByTool -->|No| IsMergeCommit{Is Merge\nCommit?}
+    IsMergeCommit -->|Yes| CheckPRFlag
+    IsMergeCommit -->|No| AnalyzeCommit[Analyze with Full Context]
+    AnalyzeCommit --> AINeedsImprovement{Needs\nImprovement?}
+    AINeedsImprovement -->|No| MarkNoChanges[Mark as Processed]
+    AINeedsImprovement -->|Yes| ConfirmAmend{Amend\nCommit?}
+    ConfirmAmend -->|No| CheckPRFlag
+    ConfirmAmend -->|Yes| AmendCommit[Amend Commit Message]
+    AmendCommit --> MarkAmended[Mark as Created by Tool]
+    MarkAmended --> CheckPRFlag
+    MarkNoChanges --> CheckPRFlag
+    
+    %% PR Creation Flow
+    CheckPRFlag{Create PR?} -->|No| Complete([Complete])
+    CheckPRFlag -->|Yes| ConfirmPR{Proceed with\nCreating PR?}
+    ConfirmPR -->|No| Complete
+    ConfirmPR -->|Yes| CheckExistingPR[Check for Existing PR]
+    CheckExistingPR --> ExistingPR{PR Already\nExists?}
+    
+    %% Existing PR Flow
+    ExistingPR -->|Yes| ConfirmUpdate{Update\nExisting PR?}
+    ConfirmUpdate -->|No| GeneratePRDetails
+    ConfirmUpdate -->|Yes| PushToExisting[Push to Existing PR]
+    PushToExisting --> CheckNewCommits[Check for New Commits]
+    CheckNewCommits --> UpdatePRDesc{Update PR\nDescription?}
+    UpdatePRDesc -->|No| Complete
+    UpdatePRDesc -->|Yes| GenerateUpdatedDesc[Generate Updated Title/Description]
+    GenerateUpdatedDesc --> ConfirmUpdateDesc{Apply\nUpdates?}
+    ConfirmUpdateDesc -->|No| Complete
+    ConfirmUpdateDesc -->|Yes| UpdatePR[Update PR Title/Description]
+    UpdatePR --> Complete
+    
+    %% New PR Flow
+    ExistingPR -->|No| GeneratePRDetails[Generate PR Details with AI]
+    GeneratePRDetails --> ConfirmPRDetails{Create PR with\nthese Details?}
+    ConfirmPRDetails -->|No| Complete
+    ConfirmPRDetails -->|Yes| CheckBranchTarget{Current Branch\nis Target?}
+    CheckBranchTarget -->|Yes| CreateNewBranch[Create New Branch]
+    CheckBranchTarget -->|No| UseCurrentBranch[Use Current Branch]
+    CreateNewBranch --> ConfirmNewBranch{Confirm New\nBranch?}
+    ConfirmNewBranch -->|No| Complete
+    ConfirmNewBranch -->|Yes| CreateBranch[Create Branch]
+    CreateBranch --> PushBranch
+    UseCurrentBranch --> PushBranch[Push Branch to Remote]
+    PushBranch --> CreatePRWithGH{Create PR using\nGitHub CLI?}
+    CreatePRWithGH -->|No| ShowManualInstructions[Show Manual PR Instructions]
+    CreatePRWithGH -->|Yes| GHCliAvailable{GitHub CLI\nAvailable?}
+    GHCliAvailable -->|No| ShowManualInstructions
+    GHCliAvailable -->|Yes| CreatePRGH[Create PR with GitHub CLI]
+    CreatePRGH --> PRSuccess[PR Created Successfully]
+    ShowManualInstructions --> Complete
+    PRSuccess --> Complete
+    
+    classDef processNode fill:#d4f1f9,stroke:#0e5974,stroke-width:1px;
+    classDef decisionNode fill:#ffe6cc,stroke:#d79b00,stroke-width:1px;
+    classDef startEndNode fill:#d5e8d4,stroke:#82b366,stroke-width:2px;
+    classDef errorNode fill:#f8cecc,stroke:#b85450,stroke-width:1px;
+    
+    class Start,Complete,ExitProcess startEndNode;
+    class BranchCheck,TrackingExists,ConfirmTracking,ConfirmBranch,CheckChanges,HandleChanges,AskAI,ConfirmCommit,CommitsExists,OptimizeConfirm,IsCreatedByTool,IsMergeCommit,AINeedsImprovement,ConfirmAmend,CheckPRFlag,ConfirmPR,ExistingPR,ConfirmUpdate,UpdatePRDesc,ConfirmUpdateDesc,ConfirmPRDetails,CheckBranchTarget,ConfirmNewBranch,CreatePRWithGH,GHCliAvailable decisionNode;
+    class ExitProcess errorNode;
+    class InitConfig,GitStatus,FetchRemotes,UserSelectBranch,TargetBranchSet,AnalyzeChanges,CollectModified,GetDiffs,GenerateCommitMsg,CreateCommit,MarkCommit,OptimizeCommits,CheckLastCommit,AnalyzeCommit,MarkNoChanges,AmendCommit,MarkAmended,CheckExistingPR,PushToExisting,CheckNewCommits,GenerateUpdatedDesc,UpdatePR,GeneratePRDetails,CreateNewBranch,UseCurrentBranch,CreateBranch,PushBranch,ShowManualInstructions,CreatePRGH,PRSuccess processNode;
+```
+
 ---
 
 ## 🤝 Contributing

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -52,7 +52,7 @@ function displayCurrentConfig() {
           ? '********'
           : '(not set)'
         : value || '(not set)';
-      logger.info(`  ${bold(key)}: ${displayValue}`);
+      logger.info(`${bold(key)}: ${displayValue}`);
     });
   }
 }
@@ -76,7 +76,7 @@ async function configurationLoop() {
     logger.info('9. Show current configuration values');
     logger.info('10. Exit configuration');
 
-    const choice = await logger.prompt(yellow('Select an option:'), {
+    const choice = await logger.prompt(yellow('[CONFIG] Select an option:'), {
       type: 'select',
       options: [
         '1. Set LLM provider',
@@ -131,14 +131,14 @@ async function configurationLoop() {
     }
   }
 
-  logger.info(green('Configuration saved. Exiting configuration manager.'));
+  logger.info(green('[CONFIG] Configuration saved. Exiting configuration manager.'));
 }
 
 /**
  * Configure the LLM provider
  */
 async function configureLLMProvider() {
-  const provider = await logger.prompt(yellow('Select LLM provider:'), {
+  const provider = await logger.prompt(yellow('[CONFIG] Select LLM provider:'), {
     type: 'select',
     options: ['openai', 'anthropic', 'deepseek', 'ollama', 'gemini']
   });
@@ -146,8 +146,8 @@ async function configureLLMProvider() {
   await performAction('set', 'llmProvider', provider);
 
   // Suggest setting a model after changing provider
-  logger.info(yellow('Remember to set an appropriate model for this provider'));
-  const setModel = await logger.prompt(yellow('Would you like to set a default model now?'), {
+  logger.info(yellow('[CONFIG] Remember to set an appropriate model for this provider'));
+  const setModel = await logger.prompt(yellow('[CONFIG] Would you like to set a default model now?'), {
     type: 'confirm'
   });
 
@@ -187,13 +187,13 @@ async function configureDefaultModel(provider?: string) {
   let model;
   if (suggestedModels.length > 0) {
     const modelOptions = [...suggestedModels, 'Enter custom model name'];
-    const selectedOption = await logger.prompt(yellow('Select or enter model name:'), {
+    const selectedOption = await logger.prompt(yellow('[CONFIG] Select or enter model name:'), {
       type: 'select',
       options: modelOptions
     });
 
     if (selectedOption === 'Enter custom model name') {
-      model = await logger.prompt(yellow('Enter custom model name:'), {
+      model = await logger.prompt(yellow('[CONFIG] Enter custom model name:'), {
         type: 'text',
         initial: config.model
       });
@@ -201,7 +201,7 @@ async function configureDefaultModel(provider?: string) {
       model = selectedOption;
     }
   } else {
-    model = await logger.prompt(yellow('Enter model name:'), {
+    model = await logger.prompt(yellow('[CONFIG] Enter model name:'), {
       type: 'text',
       initial: config.model
     });
@@ -216,7 +216,7 @@ async function configureDefaultModel(provider?: string) {
 async function configureProvider(provider: string) {
   const providerConfig = config[provider as keyof typeof config] as Record<string, string>;
 
-  logger.info(bold(green(`\n=== ${provider.charAt(0).toUpperCase() + provider.slice(1)} Configuration ===`)));
+  logger.info(bold(green(`\n[CONFIG] === ${provider.charAt(0).toUpperCase() + provider.slice(1)} Configuration ===`)));
 
   // Loop through each setting for the provider
   for (const [key, value] of Object.entries(providerConfig)) {
@@ -226,7 +226,7 @@ async function configureProvider(provider: string) {
     if (key === 'baseURL' && provider === 'ollama') {
       const options = ['http://localhost:11434/api/generate', 'http://localhost:11434/api/chat', 'Enter custom URL'];
 
-      const selectedOption = await logger.prompt(yellow(`Select ${key}:`), {
+      const selectedOption = await logger.prompt(yellow(`[CONFIG] Select ${key}:`), {
         type: 'select',
         options,
         initial: options.includes(value) ? value : options[0]
@@ -234,7 +234,7 @@ async function configureProvider(provider: string) {
 
       const newValue =
         selectedOption === 'Enter custom URL'
-          ? await logger.prompt(yellow('Enter custom URL:'), {
+          ? await logger.prompt(yellow('[CONFIG] Enter custom URL:'), {
               type: 'text',
               initial: value
             })
@@ -245,7 +245,7 @@ async function configureProvider(provider: string) {
       }
     } else {
       // Standard prompt for other settings
-      const newValue = await logger.prompt(yellow(`Enter ${key} (leave empty to keep current):`), {
+      const newValue = await logger.prompt(yellow(`[CONFIG] Enter ${key} (leave empty to keep current):`), {
         type: 'text',
         initial: displayValue
       });
@@ -258,13 +258,13 @@ async function configureProvider(provider: string) {
   }
 
   // After configuring a provider, offer to set it as default
-  const makeDefault = await logger.prompt(yellow(`Set ${provider} as your default LLM provider?`), {
+  const makeDefault = await logger.prompt(yellow(`[CONFIG] Set ${provider} as your default LLM provider?`), {
     type: 'confirm'
   });
 
   if (makeDefault) {
     await performAction('set', 'llmProvider', provider);
-    logger.info(green(`${provider.charAt(0).toUpperCase() + provider.slice(1)} set as default provider.`));
+    logger.info(green(`[CONFIG] ${provider.charAt(0).toUpperCase() + provider.slice(1)} set as default provider.`));
   }
 }
 
@@ -272,13 +272,13 @@ async function configureProvider(provider: string) {
  * Reset configuration to defaults
  */
 async function resetConfig() {
-  const confirm = await logger.prompt(red('Are you sure you want to reset all settings to defaults?'), {
+  const confirm = await logger.prompt(red('[CONFIG] Are you sure you want to reset all settings to defaults?'), {
     type: 'confirm'
   });
 
   if (confirm) {
     await performAction('reset');
-    logger.info(green('All settings have been reset to defaults.'));
+    logger.info(green('[CONFIG] All settings have been reset to defaults.'));
   }
 }
 

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -27,14 +27,14 @@ export function builder(yargs: Argv): Argv<InfoArgv> {
 }
 
 export async function handler(argv: ArgumentsCamelCase<InfoArgv>) {
-  logger.info(bold(red('Basic command to display information.')));
-  logger.info(green('Node:'), bold(process.version));
-  logger.info(yellow('Processor architecture:'), process.arch);
-  logger.info(blue('Current dir:'), process.cwd());
-  logger.info(gray('Memory usage:'), process.memoryUsage());
-  logger.info(gray('Argv:'), argv);
+  logger.info(bold(red('[INFO] Basic command to display information.')));
+  logger.info(green('[INFO] Node:'), bold(process.version));
+  logger.info(yellow('[INFO] Processor architecture:'), process.arch);
+  logger.info(blue('[INFO] Current dir:'), process.cwd());
+  logger.info(gray('[INFO] Memory usage:'), process.memoryUsage());
+  logger.info(gray('[INFO] Argv:'), argv);
   if (argv.full) {
-    logger.box(gray(bold('Process config:')), process.config);
+    logger.box(gray(bold('[INFO] Process config:')), process.config);
   }
-  logger.info(`Config path: ${configInstance.path}`);
+  logger.info(`[INFO] Config path: ${configInstance.path}`);
 }

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -116,18 +116,18 @@ function initializeClients(): void {
         apiKey: config.openai.apiKey,
         baseURL: config.openai.baseURL
       });
-      logger.debug('OpenAI client initialized successfully');
+      logger.debug('[LLM-INIT] OpenAI client initialized successfully');
     } else {
-      logger.debug('Skipping OpenAI client initialization: No API key provided');
+      logger.debug('[LLM-INIT] Skipping OpenAI client initialization: No API key provided');
     }
 
     if (config.anthropic?.apiKey) {
       anthropicClient = new Anthropic({
         apiKey: config.anthropic.apiKey
       });
-      logger.debug('Anthropic client initialized successfully');
+      logger.debug('[LLM-INIT] Anthropic client initialized successfully');
     } else {
-      logger.debug('Skipping Anthropic client initialization: No API key provided');
+      logger.debug('[LLM-INIT] Skipping Anthropic client initialization: No API key provided');
     }
 
     if (config.gemini?.apiKey) {
@@ -135,12 +135,12 @@ function initializeClients(): void {
         apiKey: config.gemini.apiKey
       });
 
-      logger.debug('Google Gemini client initialized successfully');
+      logger.debug('[LLM-INIT] Google Gemini client initialized successfully');
     } else {
-      logger.debug('Skipping Google Gemini client initialization: No API key provided');
+      logger.debug('[LLM-INIT] Skipping Google Gemini client initialization: No API key provided');
     }
   } catch (error) {
-    logger.error(red(`Failed to initialize LLM clients: ${(error as Error).message}`));
+    logger.error(red(`[LLM-INIT] Failed to initialize LLM clients: ${(error as Error).message}`));
     throw new Error(`LLM client initialization failed: ${(error as Error).message}`);
   }
 }
@@ -151,9 +151,9 @@ function initializeClients(): void {
 async function ensureLogDirectory(): Promise<void> {
   try {
     await fs.mkdir(logDir, { recursive: true });
-    logger.debug(`LLM log directory ensured at: ${logDir}`);
+    logger.debug(`[LLM-LOGS] Log directory ensured at: ${logDir}`);
   } catch (error) {
-    logger.error(red(`Failed to create log directory: ${(error as Error).message}`));
+    logger.error(red(`[LLM-LOGS] Failed to create log directory: ${(error as Error).message}`));
     throw new Error(`Log directory creation failed: ${(error as Error).message}`);
   }
 }
@@ -173,11 +173,11 @@ async function logRequest(logEntry: LLMLogEntry): Promise<string> {
     // Save the request part separately in a structured JSON file for easy reuse
     await fs.writeFile(requestFilePath, JSON.stringify(logEntry, null, 2), { encoding: 'utf8' });
 
-    logger.info(green(`Request saved as ${requestFilePath} (ID: ${logEntry.id})`));
+    logger.info(green(`[LLM-LOGS] Request saved as ${requestFilePath} (ID: ${logEntry.id})`));
 
     return logEntry.id;
   } catch (error) {
-    logger.error(red(`Failed to log LLM request: ${(error as Error).message}`));
+    logger.error(red(`[LLM-LOGS] Failed to log LLM request: ${(error as Error).message}`));
     return logEntry.id;
   }
 }
@@ -235,7 +235,7 @@ async function logTokensAndCost(model: string, input: string, output?: string): 
 
       logger.info(
         yellow(
-          `Input tokens: ${inputOutputCost.inputTokens}, Output tokens: ${inputOutputCost.outputTokens}, Cost: ${inputOutputCost.cost}`
+          `[LLM-TOKENS] Input tokens: ${inputOutputCost.inputTokens}, Output tokens: ${inputOutputCost.outputTokens}, Cost: ${inputOutputCost.cost}`
         )
       );
 
@@ -251,7 +251,7 @@ async function logTokensAndCost(model: string, input: string, output?: string): 
       model,
       input
     });
-    logger.info(yellow(`Input tokens: ${inputToken.inputTokens}`));
+    logger.info(yellow(`[LLM-TOKENS] Input tokens: ${inputToken.inputTokens}`));
 
     return {
       inputTokens: inputToken.inputTokens,
@@ -260,7 +260,7 @@ async function logTokensAndCost(model: string, input: string, output?: string): 
       cost: inputToken.cost
     };
   } catch (error) {
-    logger.warn(yellow(`Failed to calculate token usage: ${(error as Error).message}`));
+    logger.warn(yellow(`[LLM-TOKENS] Failed to calculate token usage: ${(error as Error).message}`));
     return undefined;
   }
 }
@@ -276,13 +276,13 @@ async function openaiGenerate(
   }
 
   const model = options.model || config.model || 'gpt-3.5-turbo';
-  logger.info(yellow(`Making OpenAI completion request with model: ${model}`));
+  logger.info(yellow(`[OPENAI] Making completion request with model: ${model}`));
 
   // Log input tokens
   await logTokensAndCost(model, options.prompt);
 
   logger.debug(
-    `OpenAI request params: temperature=${options.temperature || 0.1}, maxTokens=${options.maxTokens || 1000000}`
+    `[OPENAI] Request params: temperature=${options.temperature || 0.1}, maxTokens=${options.maxTokens || 1000000}`
   );
 
   const clientBaseUrl = openaiClient.baseURL;
@@ -348,13 +348,13 @@ async function anthropicGenerate(
   }
 
   const model = options.model || config.model || 'claude-3-sonnet-20240229';
-  logger.info(yellow(`Making Anthropic completion request with model: ${model}`));
+  logger.info(yellow(`[ANTHROPIC] Making completion request with model: ${model}`));
 
   // Log input tokens
   await logTokensAndCost(model, options.prompt);
 
   logger.debug(
-    `Anthropic request params: temperature=${options.temperature || 0.1}, maxTokens=${options.maxTokens || 1000000}`
+    `[ANTHROPIC] Request params: temperature=${options.temperature || 0.1}, maxTokens=${options.maxTokens || 1000000}`
   );
 
   try {
@@ -401,13 +401,13 @@ async function deepseekGenerate(
   const model = options.model || config.model || 'deepseek-chat';
   const apiUrl = config.deepseek?.baseURL || 'https://api.deepseek.com/v1/chat/completions';
 
-  logger.info(yellow(`Making DeepSeek completion request with model: ${model}`));
+  logger.info(yellow(`[DEEPSEEK] Making completion request with model: ${model}`));
 
   // Log input tokens
   await logTokensAndCost(model, options.prompt);
 
   logger.debug(
-    `DeepSeek request params: temperature=${options.temperature || 0.1}, maxTokens=${options.maxTokens || 1000000}, url=${apiUrl}`
+    `[DEEPSEEK] Request params: temperature=${options.temperature || 0.1}, maxTokens=${options.maxTokens || 1000000}, url=${apiUrl}`
   );
 
   try {
@@ -466,12 +466,12 @@ async function ollamaGenerate(
   const model = options.model || config.model || 'llama2';
   const apiUrl = config.ollama?.baseURL || 'http://localhost:11434/api/generate';
 
-  logger.info(yellow(`Making Ollama completion request with model: ${model}`));
+  logger.info(yellow(`[OLLAMA] Making completion request with model: ${model}`));
 
   // Log input tokens
   await logTokensAndCost(model, options.prompt);
 
-  logger.debug(`Ollama request params: temperature=${options.temperature || 0.1}, url=${apiUrl}`);
+  logger.debug(`[OLLAMA] Request params: temperature=${options.temperature || 0.1}, url=${apiUrl}`);
 
   try {
     const body = JSON.stringify({
@@ -537,12 +537,12 @@ async function geminiGenerate(options: CompletionOptions): Promise<{
   }
 
   const model = options.model || config.model || 'gemini-1.5-pro';
-  logger.info(yellow(`Making Gemini completion request with model: ${model}`));
+  logger.info(yellow(`[GEMINI] Making completion request with model: ${model}`));
 
   // Log input tokens
   await logTokensAndCost(model, options.prompt);
 
-  logger.debug(`Gemini request params: temperature=${options.temperature || 0.1}, model=${model}`);
+  logger.debug(`[GEMINI] Request params: temperature=${options.temperature || 0.1}, model=${model}`);
 
   try {
     // Get the generative model
@@ -578,7 +578,7 @@ export const generateCompletion = async (
   provider: LLMProvider,
   options: CompletionOptions
 ): Promise<{ response: unknown; text: string; requestId: string }> => {
-  logger.info(yellow(`Generating completion using ${provider}...`));
+  logger.info(yellow(`[LLM] Generating completion using ${provider}...`));
 
   // Ensure clients are initialized
   if (!openaiClient && !anthropicClient && !geminiClient) {
@@ -587,7 +587,7 @@ export const generateCompletion = async (
 
   // Ensure log directory exists
   await ensureLogDirectory().catch((err) => {
-    logger.warn(yellow(`Failed to ensure log directory, but will continue: ${err.message}`));
+    logger.warn(yellow(`[LLM] Failed to ensure log directory, but will continue: ${err.message}`));
   });
 
   const startTime = Date.now();
@@ -666,7 +666,7 @@ export const generateCompletion = async (
     // Only log the request if the logRequest option is true
     if (options.logRequest) {
       await logRequest(logEntry).catch((err) => {
-        logger.warn(yellow(`Failed to log request, but will continue: ${err.message}`));
+        logger.warn(yellow(`[LLM] Failed to log request, but will continue: ${err.message}`));
       });
     }
 
@@ -679,15 +679,15 @@ export const generateCompletion = async (
     // Only log the error if the logRequest option is true
     if (options.logRequest) {
       await logRequest(logEntry).catch((err) => {
-        logger.warn(yellow(`Failed to log error request, but will continue: ${err.message}`));
+        logger.warn(yellow(`[LLM] Failed to log error request, but will continue: ${err.message}`));
       });
     }
 
-    logger.error(red(`Error generating completion with ${provider}: ${(error as Error).message}`));
+    logger.error(red(`[LLM] Error generating completion with ${provider}: ${(error as Error).message}`));
     throw error;
   }
 };
 
 // Initialize on module load
 initializeClients();
-ensureLogDirectory().catch((err) => logger.error(red(`Log directory initialization error: ${err.message}`)));
+ensureLogDirectory().catch((err) => logger.error(red(`[LLM-LOGS] Log directory initialization error: ${err.message}`)));


### PR DESCRIPTION
## Summary
This PR introduces the ability to update existing pull requests, enhances the LLM request log viewer with multi-entry display, and adds functionality to delete log files.

## Problem Statement
Previously, the CLI could only create new PRs and the log viewer was limited to displaying single files without options for management like deletion.

## Changes Made
- Implemented a workflow to check for an existing PR on the current branch.
- Added a prompt to allow users to update an existing PR instead of creating a new one.
- Added logic to push new commits to the existing PR's branch.
- Implemented AI-powered generation of updated PR titles and descriptions based on new commits and the existing PR content.
- Added functionality to update existing PRs on GitHub using the `gh pr edit` command.
- Enhanced the log viewer command (`logs`) to provide an interactive menu.
- Added an option within the log viewer to delete all LLM request log files.
- Modified the log file display to handle JSONL format, showing multiple log entries sequentially with a prompt to continue.
- Added contextual prefixes (e.g., `[CONFIG]`, `[GIT]`, `[LOGS-VIEWER]`) to logger output for improved clarity and debugging.

## Recent Updates
- Added a Mermaid diagram illustrating the GGPR workflow.
- Included nodes for key steps like configuration, git status checks, branch handling, commit optimization, and PR creation.
- Used different node styles to distinguish process steps, decisions, and start/end points.
- Improved readability of the Mermaid flowchart in `README.md`.
- Added blank lines between flowchart sections for better visual separation.
- Adjusted formatting for improved clarity.